### PR TITLE
Replace http:// by simply //

### DIFF
--- a/fas_openid/templates/layout.html
+++ b/fas_openid/templates/layout.html
@@ -6,7 +6,7 @@
         {% endif %}
 
         <link rel="shortcut icon" type="image/vnd.microsoft.icon"
-            href="http://fedoraproject.org/static/images/favicon.ico"/>
+            href="//fedoraproject.org/static/images/favicon.ico"/>
 
         <link rel="openid.server" href="{{config['OPENID_ENDPOINT']}}">
         <link rel="openid2.provider" href="{{config['OPENID_ENDPOINT']}}">


### PR DESCRIPTION
This makes the link using the current protocol either http or https
according to the protocol under which the application is deployed.
This prevent any warnings of an https page refering to element
which are http.
